### PR TITLE
fix: Update Action Name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "xealth auto cherry pick action"
+name: "Cherry-Pick Github Action"
 description: "GitHub action for cherry pick commits from Pull Requests into Release branches"
 inputs:
   token:


### PR DESCRIPTION
Unable to publish to GitHub marketplace since the name needs to be unique. 

There shouldn't be any actions under this name. 