### PR TITLE
fix: build command for publish action

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "description": "A Cherry Pick GitHub Action 🍒",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run package ",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
     "package": "ncc build --source-map --license license.txt",
     "test": "jest --runInBand",
-    "all": "npm run test && npm run build && npm run format && npm run lint && npm run package"
+    "all": "npm run test && npm run format && npm run lint && npm run build"
   },
   "repository": {
     "type": "git",

--- a/test/integration/main.int.test.ts
+++ b/test/integration/main.int.test.ts
@@ -1,4 +1,4 @@
-import { findBranchesToCherryPick } from "../../src/index"
+import { findBranchesToCherryPick } from "../../src"
 import * as github from '@actions/github'
 describe('findBranchesToCherryPickMaybe', () => {
   it('should return array of strings', () => {

--- a/test/unit/index.unit.test.ts
+++ b/test/unit/index.unit.test.ts
@@ -1,4 +1,4 @@
-import {filterExecutionStatuses, ExecutionStatus, Statuses} from '../../src/index'
+import {filterExecutionStatuses} from '../../src'
 describe('filterExecutionStatuses', () => {
   const Statuses = [
     {


### PR DESCRIPTION
https://github.com/JasonEtco/build-and-tag-action uses `build` in package.json to compile with `ncc`. 

Our `package.json` `build` command only had `tsc`, which would result in missing files in the `publish.yml` workflow. 